### PR TITLE
Fix LRP visualization

### DIFF
--- a/baselines/ViT/generate_visualizations.py
+++ b/baselines/ViT/generate_visualizations.py
@@ -72,11 +72,11 @@ def compute_saliency_and_save(args):
                 # Res = Res - Res.mean()
 
             elif args.method == 'lrp':
-                Res = lrp.generate_LRP(data, start_layer=1, index=index).reshape(data.shape[0], 1, 14, 14)
+                Res = orig_lrp.generate_LRP(data, start_layer=1, method="grad", index=index).reshape(data.shape[0], 1, 14, 14)
                 # Res = Res - Res.mean()
 
             elif args.method == 'transformer_attribution':
-                Res = lrp.generate_LRP(data, start_layer=1, method="grad", index=index).reshape(data.shape[0], 1, 14, 14)
+                Res = lrp.generate_LRP(data, start_layer=1, method="transformer_attribution", index=index).reshape(data.shape[0], 1, 14, 14)
                 # Res = Res - Res.mean()
 
             elif args.method == 'full_lrp':


### PR DESCRIPTION
Existing code used the lrp instance instead of orig_lrp, which led to the same attribution as the transformer attribution.  Following this change the produced attributions are different as expected.

Also updated the transformer visualization to use method="transformer_attribution" instead of the legacy method="grad". This change has not effect, and was made to align the visualization code with the rest of the repo for consistency.