### PR TITLE
Fixed a bug that resulted in SequenceClassifierOutput module not found error

### DIFF
--- a/BERT_explainability/modules/BERT/BertForSequenceClassification.py
+++ b/BERT_explainability/modules/BERT/BertForSequenceClassification.py
@@ -7,6 +7,8 @@ import torch.nn as nn
 from typing import List, Any
 import torch
 from BERT_rationale_benchmark.models.model_utils import PaddedSequence
+from transformers.modeling_outputs import SequenceClassifierOutput
+
 
 
 class BertForSequenceClassification(BertPreTrainedModel):


### PR DESCRIPTION
While attempting to utilize this repo for my research purposes, I realized that there were some missing imports that resulted in frequent <module_name> not found errors